### PR TITLE
Document accessibility setup for Samsung and Pixel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # AddressAlarm 🚨
 
-**AddressAlarm** is an open-source Android app that helps anyone flag and avoid risky, curious or problematic addresses.  
+**AddressAlarm** is an open-source Android app that helps anyone flag and avoid risky, curious or problematic addresses.
 It runs **100% on-device**, watching for addresses through Accessibility, and alerts you when a location matches your personal "do-not-enter" or "use caution" list.
+
+> **Test build label:** The current pre-release APK installs under the launcher name **FlagDrive**. You will see this name when granting permissions or enabling the accessibility service. The branding will switch to AddressAlarm in a future build.
 
 Originally designed with gig workers in mind, the tool now serves a much broader purpose — useful for **law enforcement, social workers, real estate agents, contractors, utility workers, and the general public** who want a personal safety layer for navigating locations.
 
@@ -41,8 +43,8 @@ Originally designed with gig workers in mind, the tool now serves a much broader
 4. Build & Run on an Android device or emulator
 
 Additional guides are available in the [`docs/`](docs) directory:
-- [Overview](docs/OVERVIEW.md) – Project background and audience.
-- [Installation](docs/INSTALLATION.md) – Sideloading and setup walkthrough.
+- [Overview](docs/OVERVIEW.md) – Project background and audience (also notes the temporary FlagDrive label).
+- [Installation](docs/INSTALLATION.md) – Sideloading, accessibility walkthroughs for Pixel/Samsung, and other setup details.
 
 ---
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -40,11 +40,18 @@ This document describes how to produce a signed release APK, verify it, and prep
 2. Tag the release with `v<MAJOR.MINOR.PATCH>` and point it to the `main` branch commit.
 3. Paste the changelog entry into the release notes.
 4. Upload the signed APK and any supplemental assets (screenshots, checksum file).
-5. Publish the release.
+5. Call out in the release notes that the build currently installs under the launcher name **FlagDrive** and link to the accessibility enablement walkthrough in `docs/INSTALLATION.md`.
+6. Publish the release.
 
 ## 6. Update the website
 1. Edit `docs/index.html` to point the **Download APK** button to the new release asset URL.
 2. Update any version-specific copy.
 3. Commit and push changes so GitHub Pages serves the latest content.
+
+## 7. QA device setup instructions
+1. Smoke-test the release APK on at least one Google Pixel (Android 14 or 13) and one Samsung Galaxy (One UI 6 or 5).
+2. Follow the accessibility enablement instructions in `docs/INSTALLATION.md` to confirm wording and screenshots still match reality.
+3. Verify that system dialogs present the temporary **FlagDrive (AddressAlarm)** name so users can find the correct service.
+4. If OEMs change menu labels, update the installation guide before publishing the release.
 
 Following this checklist ensures each AddressAlarm release is reproducible, verifiable, and accompanied by the information users need to trust the download.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -3,6 +3,8 @@
 This guide walks you through installing the AddressAlarm Android application from a manually downloaded APK and enabling the accessibility service so alerts can appear over supported apps.
 
 > **Note:** A signed release APK is not yet published. Once available, download it from the project releases page.
+>
+> **Temporary app label:** The test build currently installs with the launcher name **FlagDrive**. When enabling permissions or accessibility, look for "FlagDrive (AddressAlarm)" until the final branding ships.
 
 ## 1. Prepare your device
 1. Use an Android device running Android 8.0 (Oreo) or newer.
@@ -21,10 +23,44 @@ This guide walks you through installing the AddressAlarm Android application fro
 3. After installation, tap **Open** to launch AddressAlarm.
 
 ## 4. Enable the accessibility service
-1. In AddressAlarm, complete any initial onboarding prompts.
-2. Navigate to **Settings → Accessibility → Installed services** on your device.
-3. Select **AddressAlarm** and toggle it on.
-4. Approve the permissions request so the service can observe screen content for addresses.
+
+The steps vary slightly between Android versions and manufacturers. Use the walkthrough below that matches your device. In each flow, the service appears as **FlagDrive** or **FlagDrive (AddressAlarm)** until the production name ships.
+
+### Google Pixel (Android 14 and Android 13)
+1. Open the **Settings** app.
+2. Tap **Accessibility**.
+3. Choose **Downloaded apps** (Android 14) or **Downloaded services** (Android 13).
+4. Select **FlagDrive (AddressAlarm)**.
+5. Turn on the **Use FlagDrive** toggle.
+6. Review the on-screen explanation and tap **Allow** to grant the accessibility permission.
+7. When prompted, confirm you understand that the service can view your screen so overlays can appear.
+
+### Google Pixel (Android 12 and earlier)
+1. Open **Settings** and scroll to **Accessibility**.
+2. Under **Downloaded services**, locate **FlagDrive**.
+3. Toggle the switch to **On**.
+4. Tap **OK** or **Allow** on the confirmation dialog to grant screen-observation access.
+
+### Samsung Galaxy (One UI 6 on Android 14)
+1. Go to **Settings** and open **Accessibility**.
+2. Tap **Installed apps** (sometimes labeled **Downloaded apps**).
+3. Choose **FlagDrive (AddressAlarm)**.
+4. Enable the **On** switch and accept the permission prompts.
+5. When Samsung shows the "Allow FlagDrive to have full control of your device" dialog, tap **Allow**.
+6. Back out to **Accessibility → Advanced settings → Accessibility button** if you want quick access to disable the service later.
+
+### Samsung Galaxy (One UI 5 and earlier)
+1. Open **Settings → Accessibility**.
+2. Scroll to **Screen reader & visibility enhancements**, then select **Installed services**.
+3. Tap **FlagDrive**.
+4. Slide the toggle to **On** and confirm the warning dialog.
+5. Some older devices ask for an additional confirmation to allow the service after reboot—choose **Allow**.
+
+### Other devices / troubleshooting tips
+- If your OEM nests accessibility under **System** or **Additional settings**, search the Settings app for "Accessibility".
+- If the service toggles itself off after a reboot, revisit the screen and re-enable it. Some OEMs require you to lock the app in the recent-apps view to keep the service active.
+- Verify battery optimizations are disabled if alerts stop showing. Many devices expose this under **Settings → Apps → FlagDrive → Battery → Unrestricted**.
+- After enabling the service, return to the app and confirm the status indicator shows **Service active**.
 
 ## 5. Configure your watchlist
 1. From the app’s main screen, add addresses you want to flag, including optional notes or tags.

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -18,5 +18,7 @@ AddressAlarm is an Android accessibility companion that keeps a private, on-devi
 ## Project status
 AddressAlarm is under active development. The foundational alerting pipeline is in place, and the next milestones focus on fuzzy matching improvements, encrypted storage, voice feedback, and broader distribution.
 
+> **Naming note:** Until the production branding lands, the Android launcher icon and accessibility service appear as **FlagDrive**. This is the same AddressAlarm codebase and will be renamed in a later release.
+
 For installation and setup guidance, see [docs/INSTALLATION.md](./INSTALLATION.md).
 For upcoming work, review the [ROADMAP](../ROADMAP.md).

--- a/docs/index.html
+++ b/docs/index.html
@@ -34,6 +34,10 @@
         <a class="button" href="https://github.com/TohnJravolta/AAT/releases" target="_blank" rel="noopener">
           Download APK (coming soon)
         </a>
+        <p class="small-print">
+          Current test builds appear on-device as <strong>FlagDrive</strong>. Follow the
+          <a href="./INSTALLATION.md">installation guide</a> for Pixel and Samsung accessibility walkthroughs.
+        </p>
       </section>
 
       <section id="features">

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -79,6 +79,13 @@ header {
   font-size: 1.1rem;
 }
 
+.small-print {
+  max-width: 640px;
+  margin: 1rem auto 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
 .button {
   display: inline-block;
   padding: 0.9rem 2.5rem;


### PR DESCRIPTION
## Summary
- add detailed accessibility enablement walkthroughs for Google Pixel and Samsung Galaxy devices in the installation guide
- highlight the temporary FlagDrive app label across README, overview, and web docs so users know what to look for during setup
- update release checklist with QA steps and release-note guidance for accessibility instructions

## Testing
- not run (documentation updates only)

------
https://chatgpt.com/codex/tasks/task_e_68e2e6b2e1dc8331a01e34b3b40e442b