### PR TITLE
Improve mobile responsiveness and touch effects

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,9 @@
 
       html {
         scroll-behavior: smooth;
+        width: 100%;
+        max-width: 100%;
+        overflow-x: hidden;
       }
 
       body {
@@ -56,6 +59,7 @@
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
         overflow-x: hidden; /* Prevent horizontal scroll */
+        max-width: 100%;
       }
 
       a {
@@ -298,6 +302,9 @@
           border: 1px solid var(--border-color);
           font-weight: 600;
           color: var(--primary-glow);
+          flex: 1 1 220px;
+          max-width: min(100%, 320px);
+          word-break: break-word;
       }
 
       .footer {
@@ -324,6 +331,30 @@
           background: var(--primary-glow);
           pointer-events: none;
           box-shadow: 0 0 10px var(--primary-glow);
+      }
+
+      .tap-particle {
+          position: absolute;
+          height: 10px;
+          width: 10px;
+          border-radius: 50%;
+          background: var(--secondary-glow);
+          pointer-events: none;
+          opacity: 0.85;
+          transform: translate(-50%, -50%);
+          animation: tapBurst 600ms ease-out forwards;
+          box-shadow: 0 0 12px rgba(255, 0, 193, 0.6);
+      }
+
+      @keyframes tapBurst {
+          0% {
+              transform: translate(-50%, -50%) scale(1);
+              opacity: 1;
+          }
+          100% {
+              transform: translate(calc(-50% + var(--dx, 0px)), calc(-50% + var(--dy, 0px))) scale(0);
+              opacity: 0;
+          }
       }
 
       #music-player button {
@@ -357,6 +388,7 @@
       .tooltip .tooltip-text {
         visibility: hidden;
         width: 220px;
+        max-width: min(220px, calc(100vw - 2.5rem));
         background-color: var(--surface);
         color: var(--text);
         text-align: center;
@@ -366,12 +398,13 @@
         z-index: 10;
         bottom: 140%;
         left: 50%;
-        margin-left: -110px;
+        transform: translateX(-50%);
         opacity: 0;
         transition: opacity 0.3s;
         border: 1px solid var(--border-color);
         box-shadow: 0 5px 15px rgba(0,0,0,0.3);
         pointer-events: none;
+        word-break: break-word;
       }
       .tooltip:hover .tooltip-text {
         visibility: visible;
@@ -411,6 +444,11 @@
         box-shadow: none;
       }
 
+      body.light-mode .tap-particle {
+        background: var(--primary-glow);
+        box-shadow: 0 0 8px rgba(0, 255, 157, 0.5);
+      }
+
       body.light-mode #music-player button:hover,
       body.light-mode #music-player button:focus {
         box-shadow: none;
@@ -432,6 +470,25 @@
           flex-wrap: wrap;
           justify-content: center;
           gap: 1rem 1.5rem;
+        }
+      }
+
+      @media (max-width: 600px) {
+        .hero {
+          padding: 5rem 1.25rem 4rem;
+        }
+        section {
+          padding: 3.5rem 1.25rem;
+        }
+        .hero p,
+        section p {
+          font-size: 1rem;
+        }
+        .features-grid {
+          gap: 1.5rem;
+        }
+        .card {
+          padding: 1.75rem 1.5rem;
         }
       }
     </style>
@@ -671,13 +728,70 @@
                 document.body.appendChild(trail);
                 trails.push({ el: trail, x: -20, y: -20 });
             }
-            let mouseX = -20, mouseY = -20;
-            document.addEventListener('mousemove', e => {
-                mouseX = e.pageX;
-                mouseY = e.pageY;
-            });
+
+            let pointerX = -20, pointerY = -20;
+
+            const updatePointer = (x, y) => {
+                pointerX = x;
+                pointerY = y;
+            };
+
+            const spawnTapBurst = (x, y) => {
+                const particles = 12;
+                for (let i = 0; i < particles; i++) {
+                    const particle = document.createElement('div');
+                    particle.className = 'tap-particle';
+                    const size = 4 + Math.random() * 6;
+                    particle.style.width = `${size}px`;
+                    particle.style.height = `${size}px`;
+                    particle.style.left = `${x}px`;
+                    particle.style.top = `${y}px`;
+                    const angle = Math.random() * Math.PI * 2;
+                    const distance = 30 + Math.random() * 35;
+                    const dx = Math.cos(angle) * distance;
+                    const dy = Math.sin(angle) * distance;
+                    particle.style.setProperty('--dx', `${dx}px`);
+                    particle.style.setProperty('--dy', `${dy}px`);
+                    document.body.appendChild(particle);
+                    particle.addEventListener('animationend', () => particle.remove());
+                }
+            };
+
+            const handleTouch = (event, shouldBurst = false) => {
+                if (event.touches && event.touches.length) {
+                    const touch = event.touches[0];
+                    updatePointer(touch.pageX, touch.pageY);
+                    if (shouldBurst) {
+                        spawnTapBurst(touch.pageX, touch.pageY);
+                    }
+                }
+            };
+
+            if (window.PointerEvent) {
+                document.addEventListener('pointermove', e => {
+                    if (e.isPrimary) {
+                        updatePointer(e.pageX, e.pageY);
+                    }
+                }, { passive: true });
+                document.addEventListener('pointerdown', e => {
+                    if (!e.isPrimary) return;
+                    updatePointer(e.pageX, e.pageY);
+                    spawnTapBurst(e.pageX, e.pageY);
+                });
+            } else {
+                document.addEventListener('mousemove', e => {
+                    updatePointer(e.pageX, e.pageY);
+                });
+                document.addEventListener('mousedown', e => {
+                    updatePointer(e.pageX, e.pageY);
+                    spawnTapBurst(e.pageX, e.pageY);
+                });
+                document.addEventListener('touchstart', e => handleTouch(e, true), { passive: true });
+                document.addEventListener('touchmove', handleTouch, { passive: true });
+            }
+
             const animateTrail = () => {
-                let prevX = mouseX, prevY = mouseY;
+                let prevX = pointerX, prevY = pointerY;
                 trails.forEach(p => {
                     const currentX = p.x, currentY = p.y;
                     p.x += (prevX - currentX) / trailLag;
@@ -717,10 +831,28 @@
 
             init() {
                 document.getElementById('play-music-btn').addEventListener('click', () => this.toggle());
-                document.addEventListener('mousemove', e => {
-                    this.mousePos.x = e.clientX / window.innerWidth;
-                    this.mousePos.y = e.clientY / window.innerHeight;
-                });
+
+                const updateMousePos = (clientX, clientY) => {
+                    this.mousePos.x = Math.min(Math.max(clientX / window.innerWidth, 0), 1);
+                    this.mousePos.y = Math.min(Math.max(clientY / window.innerHeight, 0), 1);
+                };
+
+                if (window.PointerEvent) {
+                    document.addEventListener('pointermove', e => {
+                        if (e.isPrimary) {
+                            updateMousePos(e.clientX, e.clientY);
+                        }
+                    }, { passive: true });
+                } else {
+                    document.addEventListener('mousemove', e => {
+                        updateMousePos(e.clientX, e.clientY);
+                    });
+                    document.addEventListener('touchmove', e => {
+                        if (e.touches && e.touches.length) {
+                            updateMousePos(e.touches[0].clientX, e.touches[0].clientY);
+                        }
+                    }, { passive: true });
+                }
                 document.body.addEventListener('click', e => {
                     if (this.isPlaying && e.target.id !== 'play-music-btn') {
                         this.phase = (this.phase + 1) % 6;


### PR DESCRIPTION
## Summary
- refine the HTML layout to prevent horizontal scrolling on small screens and improve copy wrapping in feature lists and tooltips
- add touch-aware pointer tracking and tap burst particles so mobile taps mirror the existing desktop mouse trail effect
- update the music interaction logic to use pointer events for consistent behavior across mouse and touch inputs

## Testing
- Not run (static HTML/CSS/JS change)


------
https://chatgpt.com/codex/tasks/task_e_68e3c47d6dcc8331babf651e3164e1a3