### PR TITLE
Improve hero heading wrapping on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,13 +175,14 @@
 
       .hero h1 {
         font-family: 'Press Start 2P', cursive;
-        font-size: clamp(1.25rem, 5vw, 3rem);
+        font-size: clamp(1.15rem, 4.75vw, 3rem);
         color: var(--text-header);
         text-shadow: 0 0 15px var(--primary-glow), 0 0 25px var(--primary-glow);
         margin-bottom: 1.5rem;
         line-height: 1.4;
-        word-break: break-word;
-        hyphens: auto;
+        word-break: normal;
+        overflow-wrap: anywhere;
+        hyphens: manual;
       }
 
       .hero p {
@@ -235,16 +236,17 @@
         margin: 0 auto;
       }
 
-      section h2 {
+        section h2 {
           text-align: center;
           font-family: 'Press Start 2P', cursive;
-          font-size: clamp(1.25rem, 4.5vw, 2rem);
+          font-size: clamp(1.15rem, 4.25vw, 2rem);
           color: var(--text-header);
           text-shadow: 0 0 10px var(--secondary-glow);
           margin-bottom: 3rem;
-          word-break: break-word;
-          hyphens: auto;
-      }
+          word-break: normal;
+          overflow-wrap: anywhere;
+          hyphens: manual;
+        }
 
       .features-grid {
         display: grid;
@@ -513,10 +515,10 @@
 
       @media (max-width: 480px) {
         .hero h1 {
-          font-size: clamp(1.1rem, 8vw, 2.25rem);
+          font-size: clamp(1rem, 9vw, 2.5rem);
         }
         section h2 {
-          font-size: clamp(1.05rem, 7vw, 1.75rem);
+          font-size: clamp(1rem, 7vw, 1.75rem);
         }
         .card h3 {
           font-size: clamp(0.85rem, 5vw, 1rem);


### PR DESCRIPTION
## Summary
- prevent automatic hyphenation in the hero and section headings
- tweak responsive font scaling so long words wrap cleanly on small screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3d87b730083319ffab2f0170ce7f2