### PR TITLE
Add SQLCipher database encryption and migration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,6 +63,9 @@ dependencies {
   implementation("androidx.room:room-runtime:$roomVersion") // Added
   implementation("androidx.room:room-ktx:$roomVersion") // Ensured version
   kapt("androidx.room:room-compiler:$roomVersion") // Ensured version
+  implementation("androidx.sqlite:sqlite-ktx:2.4.0")
+  implementation("net.zetetic:android-database-sqlcipher:4.5.5")
+  implementation("androidx.security:security-crypto:1.1.0-alpha06")
 
   val composeBom = platform("androidx.compose:compose-bom:2024.06.00")
   implementation(composeBom)
@@ -81,6 +84,9 @@ dependencies {
 
   implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
   implementation("com.google.android.material:material:1.12.0")
+
+  androidTestImplementation("androidx.test:core:1.5.0")
+  androidTestImplementation("androidx.test.ext:junit:1.1.5")
 }
 
 kapt {

--- a/app/src/androidTest/java/org/flagdrive/data/DatabaseEncryptionTest.kt
+++ b/app/src/androidTest/java/org/flagdrive/data/DatabaseEncryptionTest.kt
@@ -1,0 +1,70 @@
+package org.flagdrive.data
+
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteException
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SmallTest
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import net.sqlcipher.database.SQLiteDatabase as SQLCipherDatabase
+import net.sqlcipher.database.SupportFactory
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@SmallTest
+class DatabaseEncryptionTest {
+
+    private lateinit var context: Context
+    private lateinit var dbName: String
+    private val keyProvider by lazy { EncryptionKeyProvider.getInstance(context) }
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        dbName = "encryption-test.db"
+        val dbFile = context.getDatabasePath(dbName)
+        if (dbFile.exists()) {
+            dbFile.delete()
+        }
+        SQLCipherDatabase.loadLibs(context)
+    }
+
+    @After
+    fun tearDown() {
+        val dbFile = context.getDatabasePath(dbName)
+        if (dbFile.exists()) {
+            dbFile.delete()
+        }
+    }
+
+    @Test
+    fun openingWithPlainSQLiteFails() {
+        val passphrase = keyProvider.getOrCreateDatabaseKey()
+        val factory = SupportFactory(passphrase.copyOf())
+
+        val database = Room.databaseBuilder(
+            context,
+            AppDatabase::class.java,
+            dbName
+        )
+            .openHelperFactory(factory)
+            .setJournalMode(androidx.room.RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)
+            .build()
+
+        database.close()
+        passphrase.fill(0)
+
+        val dbFile = context.getDatabasePath(dbName)
+        assertTrue(dbFile.exists())
+
+        assertFailsWith<SQLiteException> {
+            SQLiteDatabase.openDatabase(dbFile.path, null, SQLiteDatabase.OPEN_READONLY)
+        }
+    }
+}

--- a/app/src/main/java/org/flagdrive/data/AppDatabase.kt
+++ b/app/src/main/java/org/flagdrive/data/AppDatabase.kt
@@ -6,7 +6,7 @@ import androidx.room.TypeConverters
 
 @Database(
     entities = [FlaggedPlace::class],
-    version = 1,
+    version = 2,
     exportSchema = false // Changed to false to suppress warning
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/org/flagdrive/data/EncryptionKeyProvider.kt
+++ b/app/src/main/java/org/flagdrive/data/EncryptionKeyProvider.kt
@@ -1,0 +1,125 @@
+package org.flagdrive.data
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.security.KeyStore
+import java.security.SecureRandom
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+/**
+ * Provides the SQLCipher database key, generating and wrapping it with an AES key stored in the
+ * Android Keystore. The wrapped bytes are persisted in EncryptedSharedPreferences so the key never
+ * leaves the device.
+ */
+class EncryptionKeyProvider private constructor(context: Context) {
+
+    private val appContext = context.applicationContext
+    private val prefs: SharedPreferences by lazy { encryptedPreferences() }
+
+    fun getOrCreateDatabaseKey(): ByteArray = synchronized(LOCK) {
+        val wrappingKey = getOrCreateWrappingKey()
+        val encoded = prefs.getString(PREF_KEY_WRAPPED_DB_KEY, null)
+        if (encoded != null) {
+            return@synchronized unwrapKey(encoded, wrappingKey)
+        }
+
+        val newKey = ByteArray(DB_KEY_SIZE_BYTES).apply { SecureRandom().nextBytes(this) }
+        val wrapped = wrapKey(newKey, wrappingKey)
+        prefs.edit().putString(PREF_KEY_WRAPPED_DB_KEY, wrapped).apply()
+        newKey
+    }
+
+    private fun encryptedPreferences(): SharedPreferences {
+        val masterKey = MasterKey.Builder(appContext)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+
+        return EncryptedSharedPreferences.create(
+            appContext,
+            PREF_FILE_NAME,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }
+
+    private fun getOrCreateWrappingKey(): SecretKey {
+        val keyStore = KeyStore.getInstance(ANDROID_KEY_STORE).apply { load(null) }
+        val existing = keyStore.getKey(KEY_ALIAS, null) as? SecretKey
+        if (existing != null) {
+            return existing
+        }
+
+        val keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEY_STORE)
+        val parameterSpec = KeyGenParameterSpec.Builder(
+            KEY_ALIAS,
+            KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+        )
+            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+            .setKeySize(DB_KEY_SIZE_BITS)
+            .build()
+        keyGenerator.init(parameterSpec)
+        return keyGenerator.generateKey()
+    }
+
+    private fun wrapKey(plainKey: ByteArray, wrappingKey: SecretKey): String {
+        val cipher = Cipher.getInstance(AES_GCM_TRANSFORMATION)
+        cipher.init(Cipher.ENCRYPT_MODE, wrappingKey)
+        val iv = cipher.iv
+        val encrypted = cipher.doFinal(plainKey)
+
+        val payload = ByteBuffer.allocate(IV_LENGTH_HEADER_BYTES + iv.size + encrypted.size)
+            .order(ByteOrder.BIG_ENDIAN)
+            .putInt(iv.size)
+            .put(iv)
+            .put(encrypted)
+            .array()
+        return Base64.encodeToString(payload, Base64.NO_WRAP)
+    }
+
+    private fun unwrapKey(encoded: String, wrappingKey: SecretKey): ByteArray {
+        val payload = Base64.decode(encoded, Base64.NO_WRAP)
+        val buffer = ByteBuffer.wrap(payload).order(ByteOrder.BIG_ENDIAN)
+        val ivSize = buffer.int
+        val iv = ByteArray(ivSize).also { buffer.get(it) }
+        val cipherText = ByteArray(buffer.remaining()).also { buffer.get(it) }
+
+        val cipher = Cipher.getInstance(AES_GCM_TRANSFORMATION)
+        cipher.init(Cipher.DECRYPT_MODE, wrappingKey, GCMParameterSpec(GCM_AUTH_TAG_LENGTH_BITS, iv))
+        return cipher.doFinal(cipherText)
+    }
+
+    companion object {
+        private const val PREF_FILE_NAME = "flagdrive.encryption"
+        private const val PREF_KEY_WRAPPED_DB_KEY = "wrapped_db_key"
+        private const val KEY_ALIAS = "flagdrive.db.wrapper"
+        private const val DB_KEY_SIZE_BITS = 256
+        private const val DB_KEY_SIZE_BYTES = DB_KEY_SIZE_BITS / 8
+        private const val AES_GCM_TRANSFORMATION = "AES/GCM/NoPadding"
+        private const val GCM_AUTH_TAG_LENGTH_BITS = 128
+        private const val IV_LENGTH_HEADER_BYTES = 4
+        private const val ANDROID_KEY_STORE = "AndroidKeyStore"
+
+        private val LOCK = Any()
+
+        @Volatile
+        private var instance: EncryptionKeyProvider? = null
+
+        fun getInstance(context: Context): EncryptionKeyProvider {
+            return instance ?: synchronized(this) {
+                instance ?: EncryptionKeyProvider(context).also { instance = it }
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/flagdrive/data/PlaintextDatabaseMigrator.kt
+++ b/app/src/main/java/org/flagdrive/data/PlaintextDatabaseMigrator.kt
@@ -1,0 +1,154 @@
+package org.flagdrive.data
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteException
+import android.util.Log
+import java.io.File
+
+/**
+ * Handles migrating the legacy plaintext Room database into the encrypted SQLCipher database.
+ * Data is staged in memory and the original file is kept as a backup until the migration succeeds.
+ */
+class PlaintextDatabaseMigrator(context: Context) {
+
+    private val appContext = context.applicationContext
+    private val originalFile = appContext.getDatabasePath(DATABASE_NAME)
+    private val statePrefs: SharedPreferences =
+        appContext.getSharedPreferences(PREF_FILE_NAME, Context.MODE_PRIVATE)
+
+    /**
+     * Extracts rows from the legacy plaintext database if it exists and has not already been migrated.
+     */
+    fun extractLegacyDataIfNeeded(): LegacyDump? {
+        if (statePrefs.getBoolean(PREF_KEY_MIGRATED, false)) {
+            return null
+        }
+
+        if (!originalFile.exists()) {
+            return null
+        }
+
+        return try {
+            val places = readLegacyRows(originalFile)
+            val backupFile = stageLegacyFile(originalFile)
+            LegacyDump(places, backupFile)
+        } catch (ex: SQLiteException) {
+            Log.w(TAG, "Skipping plaintext migration: ${ex.message}")
+            statePrefs.edit().putBoolean(PREF_KEY_MIGRATED, true).apply()
+            null
+        }
+    }
+
+    /**
+     * Inserts legacy data into the encrypted database and cleans up the staged plaintext file.
+     */
+    fun importLegacyData(database: AppDatabase, dump: LegacyDump) {
+        if (dump.places.isEmpty()) {
+            cleanupBackup(dump)
+            return
+        }
+
+        val writable = database.openHelper.writableDatabase
+        writable.beginTransaction()
+        try {
+            val statement = writable.compileStatement(INSERT_OR_REPLACE_SQL)
+            dump.places.forEach { place ->
+                statement.bindLong(1, place.id)
+                if (place.name != null) {
+                    statement.bindString(2, place.name)
+                } else {
+                    statement.bindNull(2)
+                }
+                statement.bindString(3, place.rawAddress)
+                statement.bindString(4, Converters.fromTags(place.tags))
+                if (place.notes != null) {
+                    statement.bindString(5, place.notes)
+                } else {
+                    statement.bindNull(5)
+                }
+                statement.executeInsert()
+                statement.clearBindings()
+            }
+            writable.setTransactionSuccessful()
+        } finally {
+            writable.endTransaction()
+        }
+
+        cleanupBackup(dump)
+    }
+
+    fun markEncrypted() {
+        statePrefs.edit().putBoolean(PREF_KEY_MIGRATED, true).apply()
+    }
+
+    private fun readLegacyRows(file: File): List<FlaggedPlace> {
+        val results = mutableListOf<FlaggedPlace>()
+        SQLiteDatabase.openDatabase(file.path, null, SQLiteDatabase.OPEN_READONLY).use { legacyDb ->
+            legacyDb.rawQuery(LEGACY_SELECT_SQL, null).use { cursor ->
+                val idIndex = cursor.getColumnIndexOrThrow("id")
+                val nameIndex = cursor.getColumnIndexOrThrow("name")
+                val rawAddressIndex = cursor.getColumnIndexOrThrow("rawAddress")
+                val tagsIndex = cursor.getColumnIndexOrThrow("tags")
+                val notesIndex = cursor.getColumnIndexOrThrow("notes")
+
+                while (cursor.moveToNext()) {
+                    val id = cursor.getLong(idIndex)
+                    val name = if (!cursor.isNull(nameIndex)) cursor.getString(nameIndex) else null
+                    val rawAddress = cursor.getString(rawAddressIndex)
+                    val tagsString = if (!cursor.isNull(tagsIndex)) cursor.getString(tagsIndex) else ""
+                    val notes = if (!cursor.isNull(notesIndex)) cursor.getString(notesIndex) else null
+                    results.add(
+                        FlaggedPlace(
+                            id = id,
+                            name = name,
+                            rawAddress = rawAddress,
+                            tags = Converters.toTags(tagsString),
+                            notes = notes
+                        )
+                    )
+                }
+            }
+        }
+        return results
+    }
+
+    private fun stageLegacyFile(file: File): File {
+        val backupFile = File(file.parentFile, "${file.name}.$LEGACY_BACKUP_SUFFIX")
+        if (backupFile.exists()) {
+            backupFile.delete()
+        }
+
+        if (!file.renameTo(backupFile)) {
+            file.copyTo(backupFile, overwrite = true)
+            if (!file.delete()) {
+                throw IllegalStateException("Unable to remove legacy database file ${file.path}")
+            }
+        }
+        return backupFile
+    }
+
+    private fun cleanupBackup(dump: LegacyDump) {
+        if (dump.backupFile.exists() && !dump.backupFile.delete()) {
+            Log.w(TAG, "Failed to delete legacy database backup at ${dump.backupFile.path}")
+        }
+    }
+
+    data class LegacyDump(
+        val places: List<FlaggedPlace>,
+        val backupFile: File
+    )
+
+    companion object {
+        private const val TAG = "PlaintextMigrator"
+        private const val DATABASE_NAME = "flagdrive.db"
+        private const val PREF_FILE_NAME = "flagdrive.migration.state"
+        private const val PREF_KEY_MIGRATED = "database_encrypted"
+        private const val LEGACY_BACKUP_SUFFIX = "legacy"
+        private const val LEGACY_SELECT_SQL =
+            "SELECT id, name, rawAddress, tags, notes FROM flagged_places ORDER BY id ASC"
+        private const val INSERT_OR_REPLACE_SQL =
+            "INSERT OR REPLACE INTO flagged_places (id, name, rawAddress, tags, notes) VALUES (?, ?, ?, ?, ?)"
+    }
+}

--- a/app/src/main/java/org/flagdrive/di/ServiceLocator.kt
+++ b/app/src/main/java/org/flagdrive/di/ServiceLocator.kt
@@ -2,23 +2,55 @@ package org.flagdrive.di
 
 import android.content.Context
 import androidx.room.Room
+import androidx.room.RoomDatabase
+import net.sqlcipher.database.SQLiteDatabase
+import net.sqlcipher.database.SupportFactory
 import org.flagdrive.data.AppDatabase
+import org.flagdrive.data.EncryptionKeyProvider
+import org.flagdrive.data.PlaintextDatabaseMigrator
 import org.flagdrive.data.PlacesRepository
 
 object ServiceLocator {
     @Volatile private var db: AppDatabase? = null
     @Volatile private var repo: PlacesRepository? = null
+    @Volatile private var keyProvider: EncryptionKeyProvider? = null
 
     fun repository(context: Context): PlacesRepository {
+        val appContext = context.applicationContext
         val database = db ?: synchronized(this) {
-            db ?: Room.databaseBuilder(
-                context.applicationContext,
-                AppDatabase::class.java, "flagdrive.db"
-            ).build().also { db = it }
+            db ?: buildDatabase(appContext).also { db = it }
         }
 
         return repo ?: synchronized(this) {
             repo ?: PlacesRepository(database.flaggedPlaceDao()).also { repo = it }
         }
     }
+
+    private fun buildDatabase(context: Context): AppDatabase {
+        val provider = keyProvider ?: EncryptionKeyProvider.getInstance(context).also { keyProvider = it }
+        val migrator = PlaintextDatabaseMigrator(context)
+        val legacyDump = migrator.extractLegacyDataIfNeeded()
+
+        SQLiteDatabase.loadLibs(context)
+        val passphrase = provider.getOrCreateDatabaseKey()
+        val factory = SupportFactory(passphrase.copyOf())
+
+        val database = Room.databaseBuilder(
+            context,
+            AppDatabase::class.java,
+            DATABASE_NAME
+        )
+            .openHelperFactory(factory)
+            .setJournalMode(RoomDatabase.JournalMode.WRITE_AHEAD_LOGGING)
+            .build()
+
+        passphrase.fill(0)
+
+        legacyDump?.let { migrator.importLegacyData(database, it) }
+        migrator.markEncrypted()
+
+        return database
+    }
+
+    private const val DATABASE_NAME = "flagdrive.db"
 }


### PR DESCRIPTION
## Summary
- add SQLCipher, security crypto, and testing dependencies needed for encrypted Room access
- create a keystore-backed EncryptionKeyProvider and PlaintextDatabaseMigrator to secure database data and upgrade legacy installs
- wire the encrypted SupportFactory into the ServiceLocator and add an instrumentation test confirming the database cannot be opened in plaintext

## Testing
- sh gradlew test *(fails: gradle-wrapper.jar not found in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e502e430888331a217c87470b4824d