### PR TITLE
Ensure tooltips shift into view on first touch

### DIFF
--- a/index.html
+++ b/index.html
@@ -996,9 +996,6 @@ Maps / Gig App ➜ Small overlay reminder just for you
             if (!tooltipText) return;
             tooltipText.style.setProperty('--tooltip-shift', '0px');
             requestAnimationFrame(() => {
-                if (window.getComputedStyle(tooltipText).visibility !== 'visible') {
-                    return;
-                }
                 const rect = tooltipText.getBoundingClientRect();
                 const viewportPadding = 16;
                 let shift = 0;


### PR DESCRIPTION
## Summary
- remove the visibility gate from the tooltip adjustment logic so repositioning happens during the first touch interaction

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e76010dc6483319696e65c20f32b53