### PR TITLE
Add setup walkthrough video to landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ Originally designed with gig workers in mind, the tool now serves a much broader
 
 ---
 
+## 🎥 Setup walkthrough & live demo
+
+[Watch the initial configuration walkthrough and live demo on YouTube](https://www.youtube-nocookie.com/embed/EpV65R8QoEg?si=93ZitphvSeRuii4y).
+The video covers downloading the APK, granting accessibility permissions, enabling notifications, tuning alerts, and shows AddressAlarm catching a flagged location in real time so you can follow along from a fresh install.
+
+---
+
 ## 📱 Screenshots (Coming Soon)
 *(Add screenshots here once you have a stable build to show)*
 

--- a/index.html
+++ b/index.html
@@ -291,6 +291,42 @@
         margin-right: auto;
       }
 
+      .video-subtitle {
+        font-family: 'Press Start 2P', cursive;
+        font-size: clamp(0.9rem, 2.8vw + 0.1rem, 1.25rem);
+        color: var(--primary-glow);
+        text-shadow: 0 0 12px rgba(0, 255, 157, 0.5);
+        margin-bottom: 1rem;
+      }
+
+      .video-description {
+        max-width: 760px;
+        margin: 0 auto 2rem;
+        color: var(--text);
+      }
+
+      .video-wrapper {
+        position: relative;
+        width: 100%;
+        max-width: 960px;
+        margin: 0 auto 3rem;
+        padding-bottom: 56.25%;
+        border-radius: var(--border-radius);
+        overflow: hidden;
+        border: 1px solid var(--border-color);
+        box-shadow: 0 0 35px rgba(0, 255, 157, 0.12);
+        background: #000;
+      }
+
+      .video-wrapper iframe {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        border: 0;
+      }
+
       #how-it-works ol {
           list-style: none;
           padding-left: 0;
@@ -589,6 +625,16 @@
         box-shadow: 0 5px 15px rgba(0,0,0,0.1);
       }
 
+      body.light-mode .video-wrapper {
+        border-color: rgba(0, 0, 0, 0.08);
+        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+      }
+
+      body.light-mode .video-subtitle {
+        text-shadow: none;
+        color: #006442;
+      }
+
       body.light-mode .trail {
         background: var(--primary-glow);
         box-shadow: none;
@@ -811,6 +857,20 @@ Maps / Gig App ➜ Small overlay reminder just for you
       <section id="how-it-works">
         <div class="section-inner">
           <h2>Getting Started is Simple</h2>
+          <h3 class="video-subtitle">Watch the full setup walkthrough &amp; live demo</h3>
+          <p class="video-description">
+            Learn how to install AddressAlarm, grant the right permissions, enable notifications, and see a real-world alert in action.
+            The video walks you from a blank device to a fully configured watchlist in minutes.
+          </p>
+          <div class="video-wrapper">
+            <iframe
+              src="https://www.youtube-nocookie.com/embed/EpV65R8QoEg?si=93ZitphvSeRuii4y"
+              title="AddressAlarm setup and demo"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              referrerpolicy="strict-origin-when-cross-origin"
+              allowfullscreen
+            ></iframe>
+          </div>
           <ol>
             <li><strong>Download the APK</strong> from the latest GitHub release.</li>
             <li><strong>Install the app</strong> and enable the "AddressAlarm" accessibility service in your phone's settings.</li>
@@ -819,7 +879,7 @@ Maps / Gig App ➜ Small overlay reminder just for you
             <li><strong>Get alerted!</strong> When a flagged address appears in a monitored app, a warning overlay will appear.</li>
           </ol>
           <p>
-            Need a hand? Our detailed <a href="docs/INSTALLATION.md">Installation Guide</a> has step-by-step walkthroughs for Pixel, Samsung, and other devices.
+            Need a hand? Watch the full walkthrough above or follow the detailed <a href="docs/INSTALLATION.md">Installation Guide</a> for Pixel, Samsung, and other devices.
           </p>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- embed the initial configuration walkthrough video in the "How It Works" section with responsive styling
- add supporting copy so visitors know the video covers permissions, notifications, and a live demo
- link the repository README to the setup video so contributors can easily find it

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68f699e606048331a9728846f0301a84